### PR TITLE
RDK-56442: Implement Router Discovery Tool (#112)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,3 +208,6 @@ if(ENABLE_UNIT_TESTING)
     include(Tests/unit_test/unit_tests.cmake)
 endif(ENABLE_UNIT_TESTING)
 
+if(ENABLE_ROUTER_DISCOVERY_TOOL)
+    add_subdirectory(upnp)
+endif(ENABLE_ROUTER_DISCOVERY_TOOL)

--- a/upnp/CMakeLists.txt
+++ b/upnp/CMakeLists.txt
@@ -1,0 +1,43 @@
+#############################################################################
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2025 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#############################################################################
+cmake_minimum_required(VERSION 3.3)
+
+set(MODULE_NAME routerDiscovery)
+find_package(PkgConfig REQUIRED)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+
+pkg_check_modules(GLIB REQUIRED glib-2.0)
+pkg_check_modules(LIBSOUP REQUIRED libsoup-2.4)
+pkg_check_modules(GUPNP REQUIRED gupnp-1.0)
+pkg_check_modules(GSSDP REQUIRED gssdp-1.2)
+
+if (USE_TELEMETRY)
+    find_package(telemetry_msgsender REQUIRED)
+    add_definitions(-DUSE_TELEMETRY)
+    include_directories(${TELEMETRY_INCLUDE_DIRS})
+endif (USE_TELEMETRY)
+
+add_executable(${MODULE_NAME} UpnpDiscoveryManager.cpp)
+target_include_directories(${MODULE_NAME} PRIVATE  ${CMAKE_CURRENT_SOURCE_DIR} ${GLIB_INCLUDE_DIRS} ${LIBSOUP_INCLUDE_DIRS} ${GUPNP_INCLUDE_DIRS} ${GSSDP_INCLUDE_DIRS})
+target_link_libraries(${MODULE_NAME} PRIVATE ${GLIB_LIBRARIES} ${LIBSOUP_LIBRARIES} ${GUPNP_LIBRARIES} ${GSSDP_LIBRARIES})
+
+if (USE_TELEMETRY)
+    target_link_libraries(${MODULE_NAME} PRIVATE ${TELEMETRY_LIBRARIES})
+endif (USE_TELEMETRY)

--- a/upnp/UpnpDiscoveryManager.cpp
+++ b/upnp/UpnpDiscoveryManager.cpp
@@ -1,0 +1,199 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2025 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include <sstream>
+#include "UpnpDiscoveryManager.h"
+
+UpnpDiscoveryManager::UpnpDiscoveryManager()
+{
+    m_context = NULL;
+    m_controlPoint = NULL;
+    m_mainLoop = NULL;
+    m_gatewayDetails.str("");
+    m_gatewayDetails.clear();
+    m_deviceInternetGateway = "urn:schemas-upnp-org:device:InternetGatewayDevice:1";
+#if USE_TELEMETRY
+    // Initialize Telemtry  
+    t2_init("upnpdiscover");
+#endif
+}
+
+UpnpDiscoveryManager::~UpnpDiscoveryManager()
+{
+    if (m_controlPoint)
+        g_object_unref(m_controlPoint);
+    if (m_context)
+        g_object_unref(m_context);
+    if (m_mainLoop) 
+    {
+        g_main_loop_quit(m_mainLoop);
+        g_main_loop_unref(m_mainLoop);
+    }
+}
+
+/* @brief Initialise GUPNP context */
+gboolean UpnpDiscoveryManager::initialiseUpnp(const std::string& interface)
+{
+    GError *error = NULL;
+    uint8_t errCount = 0;
+
+    do
+    {
+        // Create a gupnp context
+        m_context = gupnp_context_new(NULL, interface.c_str(), UPNP_DISCOVERY_PORT, &error);
+        if (!m_context) 
+        {
+            LOG_ERR("Error creating Upnp context: %s", error->message);
+            g_clear_error(&error);
+            errCount++;
+            sleep(2);
+        }
+    } while ((m_context == NULL) && (errCount < UPNP_MAX_CONTEXT_FAIL));
+    if (errCount == UPNP_MAX_CONTEXT_FAIL)
+    {
+        LOG_ERR("Context creation failed");
+	    return false;
+    }
+
+    // Create a control point for InternetGatewayDevice
+    m_controlPoint = gupnp_control_point_new(m_context, m_deviceInternetGateway.c_str());
+    if (!m_controlPoint) 
+    {
+        LOG_ERR("Error creating control point");
+	    return false;
+    }
+
+    // Connects a callback function to a signal for InternetGatewayDevice
+    g_signal_connect(m_controlPoint, "device-proxy-available",
+                         G_CALLBACK(&UpnpDiscoveryManager::deviceProxyAvailableCallback), this);
+    return true;
+}
+
+/* @brief Telemetry Logging */
+void UpnpDiscoveryManager::logTelemetry(std::string message)
+{
+#if USE_TELEMETRY 
+    //T2 telemtery logging
+    T2ERROR t2error = t2_event_s("Router_Discovered", (char*)message.c_str());
+    if (t2error != T2ERROR_SUCCESS)
+    {
+        LOG_ERR("t2_event_s(\"%s\", \"%s\") returned error code %d", "Router_Discovered", message.c_str(), t2error);
+    }
+#endif
+}
+
+/* @brief SSDP Discovery Timeout */
+gboolean UpnpDiscoveryManager::discoveryTimeout(void *arg)
+{
+    auto manager = static_cast<UpnpDiscoveryManager*>(arg); 
+    manager->stopSearchGatewayDevice();
+    manager->m_gatewayDetails << "Unknown";
+    LOG_INFO("Router_Discovered : %s", manager->m_gatewayDetails.str().c_str());
+    manager->logTelemetry(manager->m_gatewayDetails.str().c_str()); 
+    manager->exitWait();
+    return true;
+}
+
+/* @brief Find the gateway details by sending SSDP discovery on wifi/ethernet interface */
+bool UpnpDiscoveryManager::findGatewayDevice(const std::string& interface)
+{
+    m_interface = interface;
+    //Initialise gupnp context
+    if (true == initialiseUpnp(interface))
+    {
+        //Create timer to handle upnp discovery timeout
+        g_timeout_add_seconds (UPNP_DISCOVERY_TIMEOUT_IN_SEC, GSourceFunc(&UpnpDiscoveryManager::discoveryTimeout), this);
+        // Start discovery to find InternetGatewayDevice
+        gssdp_resource_browser_set_active(GSSDP_RESOURCE_BROWSER(m_controlPoint), TRUE);
+        return true;
+    }
+    else
+    {
+        m_gatewayDetails << "Unknown";
+	LOG_INFO("Router_Discovered : %s", m_gatewayDetails.str().c_str());
+        logTelemetry(m_gatewayDetails.str().c_str()); 
+        return false;
+    }
+}
+
+/* @brief Callback getting invoked when SSDP reply is received from gateway */
+void UpnpDiscoveryManager::on_device_proxy_available(GUPnPControlPoint *controlPoint, GUPnPDeviceProxy *proxy)
+{ 
+    m_apMake = gupnp_device_info_get_manufacturer(GUPNP_DEVICE_INFO(proxy)); 
+    m_apModelName = gupnp_device_info_get_model_name(GUPNP_DEVICE_INFO(proxy));
+    m_apModelNumber = gupnp_device_info_get_model_number(GUPNP_DEVICE_INFO(proxy));
+    // Remove the string after symbol <,> For example: <manufacturer>NETGEAR,Inc.</manufacturer> 
+    m_apMake = m_apMake.substr(0, m_apMake.find(','));
+    m_apModelName = m_apModelName.substr(0, m_apModelName.find(','));
+    m_apModelNumber = m_apModelNumber.substr(0, m_apModelNumber.find(','));
+    // Stop discovery to find InternetGatewayDevice
+    stopSearchGatewayDevice(); 
+    m_gatewayDetails << m_apMake << "," << m_apModelName << "," << m_apModelNumber;
+    LOG_INFO("Router_Discovered : %s", m_gatewayDetails.str().c_str());
+    if (m_gatewayDetails.str().length() >= UPNP_T2_EVENT_DATA_LEN)
+    {
+        m_gatewayDetails.str("");
+        m_gatewayDetails.clear();
+        m_gatewayDetails << m_apModelName << "," << m_apModelNumber;
+    }
+    logTelemetry(m_gatewayDetails.str()); 
+    exitWait();
+}
+
+/* @brief Stop sending SSDP discovery */
+void UpnpDiscoveryManager::stopSearchGatewayDevice() 
+{
+    gssdp_resource_browser_set_active(GSSDP_RESOURCE_BROWSER(m_controlPoint), FALSE);
+}
+
+/* @brief Wait in gmain() loop */
+void UpnpDiscoveryManager::enterWait()
+{
+    m_mainLoop = g_main_loop_new(NULL, FALSE);
+    // gmain loop need to be running for upnp discovery
+    g_main_loop_run(m_mainLoop);
+}
+
+/* @brief Exit the gmain() loop */
+void UpnpDiscoveryManager::exitWait()
+{
+    if (m_mainLoop) 
+    {
+        g_main_loop_quit(m_mainLoop);
+        g_main_loop_unref(m_mainLoop);
+        m_mainLoop = NULL;
+    }
+}
+
+int main(int argc, char *argv[])
+{  
+    if (argc < 2) 
+    {
+        LOG_INFO("Usage: %s <interface name>", argv[0]);
+        return 1; 
+    }
+    UpnpDiscoveryManager ssdpDiscover;
+    LOG_INFO("SSDP discover to fetch InternetGatewayDevice on interface %s", argv[1]);
+    if (true == ssdpDiscover.findGatewayDevice(argv[1]))
+    {
+        ssdpDiscover.enterWait();
+	return 0;
+    }
+    return 1;
+}

--- a/upnp/UpnpDiscoveryManager.h
+++ b/upnp/UpnpDiscoveryManager.h
@@ -1,0 +1,76 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2025 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#ifndef __UPNPDISCOVERYMANAGER_H__
+#define __UPNPDISCOVERYMANAGER_H__
+
+#include <libgupnp/gupnp.h>
+#include <mutex>
+#include <string>
+#if USE_TELEMETRY
+#include <telemetry_busmessage_sender.h>
+#endif
+
+#define LOG_ERR(msg, ...)    g_printerr("ERROR: " msg "\n", ##__VA_ARGS__)
+#define LOG_INFO(msg, ...)   g_print("INFO: " msg "\n", ##__VA_ARGS__)
+
+#define UPNP_MAX_CONTEXT_FAIL  15
+#define UPNP_T2_EVENT_DATA_LEN 128
+
+class UpnpDiscoveryManager
+{
+public:
+    UpnpDiscoveryManager();
+    ~UpnpDiscoveryManager();
+    /* @brief Find the gateway details by sending SSDP discovery on wifi/ethernet interface */
+    bool findGatewayDevice(const std::string& interface);
+    /* @brief Wait in gmain() loop */
+    void enterWait();
+
+private:
+    /* @brief Telemetry Logging */
+    void logTelemetry(std::string message);
+    /* @brief SSDP Discovery Timeout */
+    static gboolean discoveryTimeout(void* arg);
+    /* @brief Exit the gmain() loop */
+    void exitWait();
+    /* @brief Initialise GUPNP context */
+    gboolean initialiseUpnp(const std::string& interface);
+    /* @brief Stop sending SSDP discovery */
+    void stopSearchGatewayDevice();
+    /* @brief Callback getting invoked when SSDP reply is received from gateway */
+    void on_device_proxy_available(GUPnPControlPoint *control_point, GUPnPDeviceProxy *proxy);
+    static void deviceProxyAvailableCallback(GUPnPControlPoint *control_point, GUPnPDeviceProxy *proxy, gpointer user_data) 
+    { 
+        auto* self = static_cast<UpnpDiscoveryManager *>(user_data);
+        self->on_device_proxy_available(control_point, proxy);
+    }
+    GUPnPContext*       m_context;
+    GUPnPControlPoint*  m_controlPoint;
+    GMainLoop*          m_mainLoop;
+    std::string         m_interface;
+    std::string         m_apMake;
+    std::string         m_apModelName;
+    std::string         m_apModelNumber;
+    std::ostringstream  m_gatewayDetails;
+    std::string         m_deviceInternetGateway;
+    static const guint  UPNP_DISCOVERY_PORT = 1901; 
+    static const int    UPNP_DISCOVERY_TIMEOUT_IN_SEC = 180; 
+};
+#endif /* __UPNPDISCOVERYMANAGER_H__ */

--- a/upnp/cmake/Findtelemetry_msgsender.cmake
+++ b/upnp/cmake/Findtelemetry_msgsender.cmake
@@ -1,0 +1,37 @@
+#############################################################################
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#############################################################################
+
+find_package(PkgConfig)
+
+find_library(TELEMETRY_LIBRARIES NAMES telemetry_msgsender)
+find_path(TELEMETRY_INCLUDE_DIRS NAMES telemetry_busmessage_sender.h)
+
+set(TELEMETRY_LIBRARIES ${TELEMETRY_LIBRARIES} CACHE PATH "Path to telemetry library")
+set(TELEMETRY_INCLUDE_DIRS ${TELEMETRY_INCLUDE_DIRS} )
+set(TELEMETRY_INCLUDE_DIRS ${TELEMETRY_INCLUDE_DIRS} CACHE PATH "Path to telemetry include")
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(TELEMETRY DEFAULT_MSG TELEMETRY_INCLUDE_DIRS TELEMETRY_LIBRARIES)
+
+mark_as_advanced(
+    TELEMETRY_FOUND
+    TELEMETRY_INCLUDE_DIRS
+    TELEMETRY_LIBRARIES
+    TELEMETRY_LIBRARY_DIRS
+    TELEMETRY_FLAGS)

--- a/upnp/scripts/getRouterInfo-NMdispatcher.sh
+++ b/upnp/scripts/getRouterInfo-NMdispatcher.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+##############################################################################
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2025 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##############################################################################
+. /etc/device.properties
+
+ifc=$1
+pid=`pidof routerDiscovery`
+if [ -n "$pid" ]; then
+    kill -9 $pid
+fi 
+echo "Starting routerDiscovery on $ifc" >> /opt/logs/routerInfo.log
+systemctl start routerDiscovery@$ifc

--- a/upnp/scripts/getRouterInfo-nlmon.sh
+++ b/upnp/scripts/getRouterInfo-nlmon.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+##############################################################################
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2025 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##############################################################################
+. /etc/device.properties
+
+cmd=$1
+mode=$2
+ifc=$3
+flags=$5
+file="/tmp/.routerdiscover"
+if [[ "$ifc" == "$WIFI_INTERFACE" || "$ifc" == "$ETHERNET_INTERFACE" ]]; then
+    if [ "$cmd" == "add" ] && [ "$flags" = "global" ]; then
+        if [ ! -f $file ]; then
+            touch /tmp/.routerdiscover
+            pid=`pidof routerDiscovery`
+            if [ -n "$pid" ]; then
+                kill -9 $pid
+            fi 
+            echo "Starting routerDiscovery on $ifc" >> /opt/logs/routerInfo.log
+            systemctl start routerDiscovery@$ifc
+        fi
+    fi
+fi

--- a/upnp/scripts/readyToGetRouterInfo.sh
+++ b/upnp/scripts/readyToGetRouterInfo.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+##############################################################################
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2025 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##############################################################################
+. /etc/device.properties
+
+ifc=$1
+file="/tmp/.routerdiscover"
+if [[ "$ifc" == "$WIFI_INTERFACE" || "$ifc" == "$ETHERNET_INTERFACE" ]]; then
+    if [ -f "$file" ]; then
+        echo "Ready to read router details" >> /opt/logs/routerInfo.log
+        rm "$file"
+    fi
+fi

--- a/upnp/scripts/routerDiscovery@.service
+++ b/upnp/scripts/routerDiscovery@.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Router Discovery Service %i
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/routerDiscovery %i


### PR DESCRIPTION
* RDK-56442: Implement Router Discovery Tool

Reason for change: Implement a tool by using gupnp library to fetch gateway details
Test Procedure: Gateway details will be available in log file
Risk: Low